### PR TITLE
replace deprecated unescape() with decodeURIComponent()

### DIFF
--- a/node_example.js
+++ b/node_example.js
@@ -12,7 +12,7 @@ function nonce(len) {
 }
 
 function forceUnicodeEncoding(string) {
-    return unescape(encodeURIComponent(string));
+    return decodeURIComponent(encodeURIComponent(string));
 }
 
 function created_signed_embed_url(options) {


### PR DESCRIPTION
`unescape` has been [removed from Web standards](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape) and is in the process of being dropped from browsers. As a result, using it will generate errors in most Javascript syntax validators and linters (i.e, jshint, eslint). Instead, use `decodeURIComponent` for the same functionality and no errors.