### PR TITLE
add external_group_id. do some cleanup

### DIFF
--- a/LookerEmbedClientExample.java
+++ b/LookerEmbedClientExample.java
@@ -19,7 +19,8 @@ public class LookerEmbedClientExample {
         String lastName = "\"Krouse\""; // converted to JSON string
         String permissions = "[\"see_user_dashboards\", \"see_lookml_dashboards\",\"access_data\",\"see_looks\"]"; // converted to JSON array
         String models = "[\"thelook\"]"; // converted to JSON array
-        String groupIds = "[5, 3]"; // converted to JSON array, can be set to null (value, not JSON) for no groups
+        String groupIDs = "[5, 3]"; // converted to JSON array, can be set to null (value, not JSON) for no groups
+        String externalGroupID = "\"awesome_engineers\"";  // converted to JSON string
         String sessionLength = "900";
         String embedURL = "/embed/sso/dashboards/3";
         String forceLoginLogout = "true"; // converted to JSON bool
@@ -29,7 +30,8 @@ public class LookerEmbedClientExample {
         try {
 
             String url = createURL(host, secret, externalUserID, firstName, lastName, permissions, models,
-                                   sessionLength, accessFilters, embedURL, forceLoginLogout, groupIds, userAttributes);
+                                   sessionLength, accessFilters, embedURL, forceLoginLogout, groupIDs,
+                                   externalGroupID, userAttributes);
             System.out.println("https://" + url);
 
         } catch(Exception e){
@@ -40,7 +42,8 @@ public class LookerEmbedClientExample {
     public static String createURL(String host, String secret,
                                    String userID, String firstName, String lastName, String userPermissions,
                                    String userModels, String sessionLength, String accessFilters,
-                                   String embedURL, String forceLoginLogout, String groupIds, String userAttributes) throws Exception {
+                                   String embedURL, String forceLoginLogout, String groupIDs,
+                                   String externalGroupID, String userAttributes) throws Exception {
 
         String path = "/login/embed/" + java.net.URLEncoder.encode(embedURL, "ISO-8859-1");
 
@@ -61,7 +64,8 @@ public class LookerEmbedClientExample {
         urlToSign += userID + "\n";
         urlToSign += userPermissions + "\n";
         urlToSign += userModels + "\n";
-        urlToSign += groupIds + "\n";
+        urlToSign += groupIDs + "\n";
+        urlToSign += externalGroupID + "\n";
         urlToSign += userAttributes + "\n";
         urlToSign += accessFilters;
 
@@ -78,7 +82,8 @@ public class LookerEmbedClientExample {
                 "&signature="          + java.net.URLEncoder.encode(signature, "ISO-8859-1") +
                 "&first_name="         + java.net.URLEncoder.encode(firstName, "ISO-8859-1") +
                 "&last_name="          + java.net.URLEncoder.encode(lastName, "ISO-8859-1") +
-                "&group_ids="          + java.net.URLEncoder.encode(groupIds, "ISO-8859-1") +
+                "&group_ids="          + java.net.URLEncoder.encode(groupIDs, "ISO-8859-1") +
+                "&external_group_id="  + java.net.URLEncoder.encode(externalGroupID, "ISO-8859-1") +
                 "&user_attributes="    + java.net.URLEncoder.encode(userAttributes, "ISO-8859-1") +
                 "&force_logout_login=" + java.net.URLEncoder.encode(forceLoginLogout, "ISO-8859-1");
 

--- a/csharp_example.cs
+++ b/csharp_example.cs
@@ -28,6 +28,7 @@ namespace SSOTest
 				Permissions = new string[] {"explore", "see_user_dashboards", "see_lookml_dashboards","access_data","see_looks", "download_with_limit"},
 				Models = new string[] { "imdb" },
 				GroupIds = new int[] {4, 2},
+				ExternalGroupId = "awesome_engineers",
 				UserAttributeMapping = user_attributes
 			};
 
@@ -48,6 +49,7 @@ namespace SSOTest
 			public bool ForceLogoutLogin { get; set; }
 			public string[] Models { get; set; }
 			public int[] GroupIds { get; set; }
+			public string ExternalGroupId { get; set; }
 			public string[] Permissions { get; set; }
 			public Dictionary<string, string> UserAttributeMapping { get; set; }
 			public string Secret { get; set; }
@@ -82,6 +84,7 @@ namespace SSOTest
 			var json_external_user_id = JsonConvert.SerializeObject(config.ExternalUserId);
 			var json_permissions = JsonConvert.SerializeObject(config.Permissions);
 			var json_group_ids = JsonConvert.SerializeObject(config.GroupIds);
+			var json_external_group_id = JsonConvert.SerializeObject(config.ExternalGroupId);
 			var json_user_attribute_values = JsonConvert.SerializeObject(config.UserAttributeMapping);
 			var json_models = JsonConvert.SerializeObject(config.Models);
 			var json_session_length = String.Format("{0:N0}", (long)config.SessionLength.TotalSeconds);
@@ -97,6 +100,7 @@ namespace SSOTest
 				json_permissions,
 				json_models,
 				json_group_ids,
+				json_external_group_id,
 				json_user_attribute_values,
 				config.AccessFilters
 			});
@@ -116,6 +120,7 @@ namespace SSOTest
 				{ "permissions", json_permissions },
 				{ "models", json_models },
 				{ "group_ids", json_group_ids },
+				{ "external_group_id", json_external_group_id },
 				{ "user_attributes", json_user_attribute_values },
 				{ "access_filters", config.AccessFilters},
 				{ "first_name", json_first_name },

--- a/node_example.js
+++ b/node_example.js
@@ -26,7 +26,8 @@ function created_signed_embed_url(options) {
     var json_last_name = JSON.stringify(options.last_name);
     var json_permissions = JSON.stringify(options.permissions);
     var json_models = JSON.stringify(options.models);
-    var json_group_ids = JSON.stringify(options.group_ids || []);
+    var json_group_ids = JSON.stringify(options.group_ids);
+    var json_external_group_id = JSON.stringify(options.external_group_id || "");
     var json_user_attributes = JSON.stringify(options.user_attributes || {});
     var json_access_filters = JSON.stringify(options.access_filters);
 
@@ -50,6 +51,7 @@ function created_signed_embed_url(options) {
     string_to_sign += json_permissions + "\n";
     string_to_sign += json_models + "\n";
     string_to_sign += json_group_ids + "\n";
+    string_to_sign += json_external_group_id + "\n";
     string_to_sign += json_user_attributes + "\n";
     string_to_sign += json_access_filters;
 
@@ -67,6 +69,7 @@ function created_signed_embed_url(options) {
         first_name: json_first_name,
         last_name: json_last_name,
         group_ids: json_group_ids,
+        external_group_id: json_external_group_id,
         user_attributes: json_user_attributes,
         force_logout_login: json_force_logout_login,
         signature: signature
@@ -87,6 +90,7 @@ function sample() {
         first_name: 'Embed Steve',
         last_name: 'Krouse',
         group_ids: [4],
+        external_group_id: 'awesome_engineers',
         permissions: ['see_user_dashboards', 'see_lookml_dashboards', 'access_data', 'see_looks'],
         models: ['thelook'],
         access_filters: {
@@ -96,7 +100,7 @@ function sample() {
         },
         user_attributes: {"an_attribute_name": "my_attribute_value", "my_number_attribute": "42"},
         session_length: fifteen_minutes,
-        embed_url: "/embed/sso/dashboards/1",
+        embed_url: "/embed/sso/dashboards/3",
         force_logout_login: true
     };
 

--- a/python_example.py
+++ b/python_example.py
@@ -15,7 +15,7 @@ class Looker:
 
 class User:
   def __init__(self, id=id, first_name=None, last_name=None,
-               permissions=[], models=[], group_ids=[],
+               permissions=[], models=[], group_ids=[], external_group_id=None,
                user_attributes={}, access_filters={}):
     self.external_user_id = json.dumps(id)
     self.first_name = json.dumps(first_name)
@@ -25,6 +25,7 @@ class User:
     self.access_filters = json.dumps(access_filters)
     self.user_attributes = json.dumps(user_attributes)
     self.group_ids = json.dumps(group_ids)
+    self.external_group_id = json.dumps(external_group_id)
 
 
 class URL:
@@ -52,6 +53,7 @@ class URL:
     string_to_sign = string_to_sign + self.user.permissions      + "\n"
     string_to_sign = string_to_sign + self.user.models           + "\n"
     string_to_sign = string_to_sign + self.user.group_ids        + "\n"
+    string_to_sign = string_to_sign + self.user.external_group_id + "\n"
     string_to_sign = string_to_sign + self.user.user_attributes  + "\n"
     string_to_sign = string_to_sign + self.user.access_filters
 
@@ -70,6 +72,7 @@ class URL:
               'permissions':         self.user.permissions,
               'models':              self.user.models,
               'group_ids':           self.user.group_ids,
+              'external_group_id':   self.user.external_group_id,
               'user_attributes':     self.user.user_attributes,
               'access_filters':      self.user.access_filters,
               'signature':           self.signature,
@@ -89,14 +92,15 @@ def test():
               first_name='Embed Wil',
               last_name='Krouse',
               permissions=['see_lookml_dashboards', 'access_data'],
-              models=['wilg_thelook'],
+              models=['thelook'],
               group_ids=[5,4],
+              external_group_id='awesome_engineers',
               user_attributes={"an_attribute_name": "my_attribute_value", "my_number_attribute": "42"},
               access_filters={'fake_model': {'id': 1}})
 
   fifteen_minutes = 15 * 60
 
-  url = URL(looker, user, fifteen_minutes, "/embed/sso/dashboards/wilg_thelook/1_business_pulse?date=Last+90+Days", force_logout_login=True)
+  url = URL(looker, user, fifteen_minutes, "/embed/dashboards/3", force_logout_login=True)
 
   print "https://" + url.to_string()
 

--- a/sso_embed.php
+++ b/sso_embed.php
@@ -3,7 +3,7 @@ date_default_timezone_set('America/Los_Angeles');
 
 $secret = "<your_secret_here>";
 
-$embedpath= "/embed/sso/dashboards/2";
+$embedpath= "/embed/dashboards/3";
 
 $host = "<your_looker_endpoint>";
 $path = "/login/embed/" . urlencode($embedpath);
@@ -17,6 +17,7 @@ $json_last_name = json_encode("<last_name>");
 $json_permissions = json_encode( array ( "see_user_dashboards", "see_lookml_dashboards", "access_data", "see_looks" ) );
 $json_models = json_encode( array ( "<your_model_name>" ) );
 $json_group_ids = json_encode( array ( 4, 2 ) );  // just some example group ids
+$json_external_group_id = json_encode("awesome_engineers");
 $json_user_attributes = json_encode( array ( "an_attribute_name" => "my_value", "my_number_attribute" => "0.231" ) );  // just some example attributes
 $accessfilters = array (
   "<your_model_name>"  =>  array ( "view_name.dimension_name" => "<value>" )
@@ -33,6 +34,7 @@ $stringtosign .= $json_external_user_id . "\n";
 $stringtosign .= $json_permissions . "\n";
 $stringtosign .= $json_models . "\n";
 $stringtosign .= $json_group_ids . "\n";
+$stringtosign .= $json_external_group_id . "\n";
 $stringtosign .= $json_user_attributes . "\n";
 $stringtosign .= $json_accessfilters;
 
@@ -47,6 +49,7 @@ $queryparams = array (
     'permissions' =>  $json_permissions,
     'models'  =>  $json_models,
     'group_ids' => $json_group_ids,
+    'external_group_id' => $json_external_group_id,
     'user_attributes' => $json_user_attributes,
     'access_filters'  =>  $json_accessfilters,
     'first_name'  =>  $json_first_name,


### PR DESCRIPTION
I did the following...
- added external_group_id to all the samples.
- did some 'cleanup' on `LookerEmbedClientExample.java` to more consistent with `ID` vs `Id`.
- got more serious in `ruby_example.rb` about making the new optional params *conditionally* part of the signed stuff in order to not break uses of these samples with older Lookers
- punted on making those params conditionally part of the sig for all the other languages :(
- cleaned up a little to make the models names and target url more consistent to ease testing.
- tested most of these changes

Review appreciated from either @stalbot or @dthorpe 