### PR TITLE
Remove "/sso" from embed urls

### DIFF
--- a/LookerEmbedClientExample.java
+++ b/LookerEmbedClientExample.java
@@ -22,7 +22,7 @@ public class LookerEmbedClientExample {
         String groupIDs = "[5, 3]"; // converted to JSON array, can be set to null (value, not JSON) for no groups
         String externalGroupID = "\"awesome_engineers\"";  // converted to JSON string
         String sessionLength = "900";
-        String embedURL = "/embed/sso/dashboards/3";
+        String embedURL = "/embed/dashboards/3";
         String forceLoginLogout = "true"; // converted to JSON bool
         String accessFilters = ("{\"thelook\": {\"dimension_a\": 1}}");  // converted to JSON Object of Objects
         String userAttributes = "{\"an_attribute_name\": \"my_attribute_value\", \"my_number_attribute\": \"42\"}";  // A Map<String, String> converted to JSON object

--- a/node_example.js
+++ b/node_example.js
@@ -100,7 +100,7 @@ function sample() {
         },
         user_attributes: {"an_attribute_name": "my_attribute_value", "my_number_attribute": "42"},
         session_length: fifteen_minutes,
-        embed_url: "/embed/sso/dashboards/3",
+        embed_url: "/embed/dashboards/3",
         force_logout_login: true
     };
 

--- a/ruby_example.rb
+++ b/ruby_example.rb
@@ -97,7 +97,7 @@ def sample
                user_attributes:    {"an_attribute_name" => "my_value", "my_number_attribute" => "0.231"},
                access_filters:     {:fake_model => {:id => 1}},
                session_length:     fifteen_minutes,
-               embed_url:          "/embed/sso/dashboards/3",
+               embed_url:          "/embed/dashboards/3",
                force_logout_login: true
              }
 


### PR DESCRIPTION
"/sso/" is no longer needed in embed urls and it is not best practice to include "/sso". "/embed/sso" redirects to "/embed".