### PR TITLE
Removing erroneous part of base path

### DIFF
--- a/csharp_example.cs
+++ b/csharp_example.cs
@@ -74,7 +74,7 @@ namespace SSOTest
 				Scheme = "https",
 				Host = config.HostName,
 				Port = config.HostPort,
-				Path = "/login/embed/" + System.Net.WebUtility.UrlEncode(targetPath)
+				Path = "/embed/" + System.Net.WebUtility.UrlEncode(targetPath)
 			};
 
 			var unixTime = (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;


### PR DESCRIPTION
Including "/login" in the base path for the embed URL leads to a "resource not found" exception in browser.  Removing that part of the path resolves the issue.